### PR TITLE
fix: use * as allowed host

### DIFF
--- a/firstapp/firstapp/settings.py
+++ b/firstapp/firstapp/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-6z+8t6ko+-k2%rfjb*z)k^q#hi-kwq0u3&yeru05-j&!%d=smf
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition


### PR DESCRIPTION


┆Issue is synchronized with this [Trello card](https://trello.com/c/T4DQ5xQb) by [Unito](https://www.unito.io)
